### PR TITLE
CI: Use actions checkout@v4, setup-go@v5, and linter

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,8 +12,8 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.22.2"
           cache: false
@@ -25,8 +25,8 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.22.2"
           cache: false

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -19,7 +19,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.55.1
   build_test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.22.2"
 
-      - name: Set up QEMU
+      - name: Set up QEMU for cross-compilation of Docker images
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Because [in CI](https://github.com/grishy/go-avahi-cname/actions/runs/8587390171) we have annotations about Node.js version.