### PR TITLE
Fix channel closure in subdomain reader

### DIFF
--- a/cmd/subdomain.go
+++ b/cmd/subdomain.go
@@ -44,6 +44,7 @@ func reader(ctx context.Context, conn *net.UDPConn) chan *dnsMsg {
 	msgCh := make(chan *dnsMsg)
 
 	go func() {
+		defer close(msgCh)
 		for {
 			dnsMsg := &dnsMsg{
 				msg: dns.Msg{},
@@ -53,7 +54,6 @@ func reader(ctx context.Context, conn *net.UDPConn) chan *dnsMsg {
 			if err != nil {
 				if ctx.Err() != nil {
 					slog.Info("closing reader")
-					close(msgCh)
 					return
 				}
 


### PR DESCRIPTION
## Summary
- ensure `reader` goroutine always closes message channel on exit

## Testing
- `go test ./...` *(fails: downloading toolchain requires network)*

------
https://chatgpt.com/codex/tasks/task_e_683f50581d7c8325a9e8fccdcb628782