### PR TITLE
Fix Compose heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Binary files can be taken as artifacts for [the Release](https://github.com/gris
 The images for each version are in [the Packages section](https://github.com/grishy/go-avahi-cname/pkgs/container/go-avahi-cname).  
 You need to provide the `/var/run/dbus/system_bus_socket` file to the container to be able to communicate with the host's Avahi daemon.
 
-Docker Composer example:
+Docker Compose example:
 
 ```yaml
 version: "3.3"


### PR DESCRIPTION
## Summary
- correct a typo in the README heading: "Docker Compose"

## Testing
- `go mod verify` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*
- `golangci-lint run ./...` *(fails: unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_683f518eab448325b837957514ec53ab