### PR TITLE
README: Privileged is needed in docker compose for AppArmor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,14 @@ Ansible task to run the container:
 - name: go-avahi-cname | Start container
   community.docker.docker_container:
     name: "go-avahi-cname"
-    image: "ghcr.io/grishy/go-avahi-cname:2.2.5"
+    image: "ghcr.io/grishy/go-avahi-cname:latest"
     restart_policy: unless-stopped
     network_mode: host
     volumes:
       - "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket" # access to avahi-daemon
+    privileged: true # AppArmor will sometimes block
+    healthcheck:
+      disable: true # No healtcheck needed as CMD crashes if fails and docker will reload
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Ansible task to run the container:
     network_mode: host
     volumes:
       - "/var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket" # access to avahi-daemon
-    privileged: true # AppArmor will sometimes block
+    security_opt:
+      - apparmor=unconfined
     healthcheck:
       disable: true # No healtcheck needed as CMD crashes if fails and docker will reload
 ```


### PR DESCRIPTION
Small readme tweak for docker compose -- needed privileged for AppArmor, and latest is probably preferred to hard coded version.